### PR TITLE
Environment Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ pipelines.
       - [Config layout](#config-layout)
     - [Pipeline](#pipeline)
       - [Pipeline Runner](#pipeline-runner)
+    - [Environment Variables](#environment-variables)
     - [Dataframes](#dataframes)
     - [Context](#context)
     - [Stages and tasks](#stages-and-tasks)
@@ -35,8 +36,6 @@ pipelines.
       - [Transform actions in `SelectField`](#transform-actions-in-selectfield)
       - [Implementing new transforms operations](#implementing-new-transforms-operations)
     - [Services](#services)
-  - [Important dependencies](#important-dependencies)
-    - [capport\_core](#capport_core)
   - [For Contributors](#for-contributors)
     - [Setup](#setup)
     - [Contribution guidelines](#contribution-guidelines)
@@ -50,7 +49,7 @@ pipelines.
     - [x] Create`HttpSingleRequestTask`
   - [ ] (transform.md) SQL support with [polars_sql](https://docs.rs/polars-sql/0.46.0/polars_sql/index.html)
   - [x] (logger.md) Setup global logging
-  - [ ] (pipeline.md) Handle environment variables
+  - [x] (pipeline.md) Handle environment variables
   - [ ] (pipeline.md) Configure runner
   - [x] (service.md) MongoDB Service
     - [ ] `find` task
@@ -217,9 +216,16 @@ Stages are currently run linearly with `PipelineRunner`. Soon this will either b
 
 Eventually this runner should be configurable as well, with the pipeline run scheduler/executor.
 
+### Environment Variables
+
+Not part of the pipeline context, but should be initialized in order for certain core functionalities
+like the logger csv reader/writer to read from the correct default input/output directories.
+
+See `EnvironmentVariablesRegistry` and `envvar.md` in the `docs/` folder for more information.
+
 ### Dataframes
 
-The whole pipeline is based on the manipulation of data with the [Polars](https://docs.rs/polars/latest/polars/) 
+The whole pipeline is based on tev.has_keyhe manipulation of data with the [Polars](https://docs.rs/polars/latest/polars/) 
 library. Tasks load from and store **manipulated Dataframes** or their lazily computed version, 
 **Lazyframes**.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ pipelines.
     - [ ] Convert existing `HttpRequestTask` to `HttpBatchRequestTask` 
     - [x] Create`HttpSingleRequestTask`
   - [ ] (transform.md) SQL support with [polars_sql](https://docs.rs/polars-sql/0.46.0/polars_sql/index.html)
+  - [x] (logger.md) Setup global logging
+  - [ ] (pipeline.md) Handle environment variables
+  - [ ] (pipeline.md) Configure runner
   - [x] (service.md) MongoDB Service
     - [ ] `find` task
   - [ ] (service.md) SQL connection Service
@@ -57,9 +60,7 @@ pipelines.
     - [ ] `insert_batched` task (from lazyframe)
     - [ ] `select` task
     - [ ] `execute` task (takes in a SQL string query and runs it directly on the database)
-  - [ ] (logger.md) Setup global logging
   - [ ] (pipeline.md) Design `PipelineScheduler`
-  - [ ] (pipeline.md) Parse runner config
 
 - Mid priority (by end June)
   - [ ] (context.md) Parse results config

--- a/capport_core/Cargo.toml
+++ b/capport_core/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2024"
 
 [dependencies]
 argh = "0.1.13"
-chrono = "0.4"
+chrono = { version = "0.4", features = ['serde'] }
 chrono-tz = "0.10.3"
-fern = { version = "0.7.1", features = ["date-based", "colored"] }
+fern = { version = "0.7.1", features = ['date-based', 'colored'] }
 log = "0.4.27"
 flexi_logger = "0.30.1"
 polars = { version = "0.46.0", features = [
@@ -17,7 +17,7 @@ polars = { version = "0.46.0", features = [
     'polars-io',
     'concat_str',
     'strings',
-    'sql'
+    'sql',
 ] }
 polars-lazy = { version = "0.46.0", features = ['dtype-struct'] }
 polars-sql = { version = "0.46.0" }

--- a/capport_core/src/context/envvar.rs
+++ b/capport_core/src/context/envvar.rs
@@ -1,0 +1,206 @@
+use std::collections::HashSet;
+
+use chrono::{DateTime, TimeZone};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    logger::common::{DEFAULT_KEYWORD_CONFIG_DIR, DEFAULT_KEYWORD_OUTPUT_DIR, DEFAULT_KEYWORD_REFDATE_DIR},
+    util::{
+        args::RunPipelineArgs,
+        common::{parse_date_str, parse_datetime_str},
+        error::{CpError, CpResult},
+    },
+};
+
+#[derive(Debug)]
+pub struct EnvironmentVariableRegistry {
+    keys: HashSet<String>,
+}
+
+impl Default for EnvironmentVariableRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EnvironmentVariableRegistry {
+    pub fn new() -> EnvironmentVariableRegistry {
+        EnvironmentVariableRegistry { keys: HashSet::new() }
+    }
+
+    pub fn init<T>(
+        default_config_dir: String,
+        default_output_dir: String,
+        default_ref_date: &T,
+    ) -> CpResult<EnvironmentVariableRegistry>
+    where
+        T: Serialize,
+    {
+        let mut ev = EnvironmentVariableRegistry::new();
+        ev.set_str(DEFAULT_KEYWORD_CONFIG_DIR, default_config_dir)?;
+        ev.set_str(DEFAULT_KEYWORD_OUTPUT_DIR, default_output_dir)?;
+
+        ev.set::<T>(DEFAULT_KEYWORD_REFDATE_DIR, default_ref_date)?;
+        Ok(ev)
+    }
+
+    pub fn from_args(args: &RunPipelineArgs) -> CpResult<EnvironmentVariableRegistry> {
+        let dt = parse_datetime_str(args.date.as_ref().unwrap())?;
+        EnvironmentVariableRegistry::init(args.config_dir.to_owned(), args.output.to_owned(), &dt)
+    }
+
+    pub fn set_str(&mut self, key: &str, value: String) -> CpResult<()> {
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        self.keys.insert(key.to_owned());
+        Ok(())
+    }
+
+    pub fn get_str(&self, key: &str) -> CpResult<String> {
+        match std::env::var(key) {
+            Ok(x) => Ok(x),
+            Err(e) => Err(CpError::ComponentError(
+                "Environment variable error: ",
+                format!("[variable: {}] {:?}", key, e),
+            )),
+        }
+    }
+
+    pub fn get<T>(&self, key: &str) -> CpResult<T>
+    where
+        T: for<'a> Deserialize<'a>,
+    {
+        let value = self.get_str(key)?;
+        Ok(serde_yaml_ng::from_str::<T>(&value)?)
+    }
+
+    pub fn set<T>(&mut self, key: &str, value: &T) -> CpResult<()>
+    where
+        T: Serialize,
+    {
+        let valstr = serde_yaml_ng::to_string(value)?;
+        unsafe {
+            std::env::set_var(key, valstr);
+        }
+        self.keys.insert(key.to_owned());
+        Ok(())
+    }
+
+    pub fn pop(&mut self, key: &str) -> CpResult<()> {
+        unsafe {
+            self.keys.remove(key);
+            std::env::remove_var(key);
+            Ok(())
+        }
+    }
+
+    pub fn has_key(&self, key: &str) -> bool {
+        self.keys.contains(key)
+    }
+
+    pub fn drop_all(&mut self) -> CpResult<()> {
+        let keys = self.keys.clone();
+        for key in keys {
+            self.pop(&key)?;
+        }
+        self.keys.clear();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        logger::common::{DEFAULT_KEYWORD_CONFIG_DIR, DEFAULT_KEYWORD_OUTPUT_DIR, DEFAULT_KEYWORD_REFDATE_DIR},
+        util::args::RunPipelineArgs,
+    };
+
+    use super::EnvironmentVariableRegistry;
+    use chrono::prelude::*;
+
+    const KEYA: &str = "KEYA";
+    #[test]
+    fn valid_set_get_variable() {
+        let mut ev = EnvironmentVariableRegistry::new();
+        let s = String::from("12345");
+        ev.set_str(KEYA, s.clone()).unwrap();
+        assert_eq!(ev.get_str(KEYA).unwrap(), s);
+        assert!(ev.has_key(KEYA));
+        ev.pop(KEYA).unwrap();
+        assert!(!ev.has_key(KEYA));
+    }
+
+    #[test]
+    fn valid_set_get_yml_variable_number() {
+        let mut ev = EnvironmentVariableRegistry::new();
+        let s = 12345;
+        ev.set::<i32>(KEYA, &s).unwrap();
+        assert_eq!(ev.get::<i32>(KEYA).unwrap(), s);
+        assert!(ev.has_key(KEYA));
+        assert!(ev.has_key(KEYA));
+        ev.pop(KEYA).unwrap();
+        assert!(!ev.has_key(KEYA));
+    }
+
+    #[test]
+    fn valid_set_get_yml_variable_date_invalid_parse() {
+        let mut ev = EnvironmentVariableRegistry::new();
+        let dt = Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap();
+        ev.set::<DateTime<Utc>>(KEYA, &dt).unwrap();
+        assert!(ev.get::<i32>(KEYA).is_err());
+        assert_eq!(ev.get::<DateTime<Utc>>(KEYA).unwrap(), dt);
+        assert!(ev.has_key(KEYA));
+        ev.pop(KEYA).unwrap();
+        assert!(!ev.has_key(KEYA));
+    }
+
+    #[test]
+    fn valid_set_drop_all() {
+        let dt = Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap();
+        let mut ev =
+            EnvironmentVariableRegistry::init("/tmp/config".to_owned(), "/tmp/output".to_owned(), &dt).unwrap();
+        assert_eq!(ev.get::<DateTime<Utc>>(DEFAULT_KEYWORD_REFDATE_DIR).unwrap(), dt);
+        assert_eq!(
+            ev.get::<String>(DEFAULT_KEYWORD_CONFIG_DIR).unwrap(),
+            "/tmp/config".to_owned()
+        );
+        assert_eq!(
+            ev.get_str(DEFAULT_KEYWORD_OUTPUT_DIR).unwrap(),
+            "/tmp/output".to_owned()
+        );
+        ev.drop_all().unwrap();
+        assert!(!ev.has_key(DEFAULT_KEYWORD_CONFIG_DIR));
+        assert!(!ev.has_key(DEFAULT_KEYWORD_OUTPUT_DIR));
+        assert!(!ev.has_key(DEFAULT_KEYWORD_REFDATE_DIR));
+    }
+
+    #[test]
+    fn valid_set_drop_all_from_args() {
+        let str_dt = [
+            (
+                Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap(),
+                "2014-11-28T12:00:09+00:00",
+            ),
+            (Utc.with_ymd_and_hms(2014, 11, 28, 0, 0, 0).unwrap(), "2014-11-28"),
+        ];
+        for (dt, dt_str) in str_dt {
+            let args = RunPipelineArgs {
+                config_dir: "/tmp/config".to_owned(),
+                output: "/tmp/output".to_owned(),
+                date: None,
+                datetime: Some(dt_str.to_string()),
+                pipeline: "ignore".to_owned(),
+                print_to_console: true,
+            };
+            let mut ev = EnvironmentVariableRegistry::from_args(&args).unwrap();
+            assert_eq!(ev.get::<DateTime<Utc>>(DEFAULT_KEYWORD_REFDATE_DIR).unwrap(), dt);
+            assert_eq!(
+                ev.get::<String>(DEFAULT_KEYWORD_CONFIG_DIR).unwrap(),
+                args.config_dir.to_owned()
+            );
+            assert_eq!(ev.get_str(DEFAULT_KEYWORD_OUTPUT_DIR).unwrap(), args.output.to_owned());
+            ev.drop_all().unwrap();
+        }
+    }
+}

--- a/capport_core/src/context/logger.rs
+++ b/capport_core/src/context/logger.rs
@@ -41,7 +41,7 @@ impl LoggerRegistry {
         self.registry.get(logger_name).map(|x| x.to_owned())
     }
 
-    pub fn start_logger(&mut self, logger_name: &str, to_console: bool) -> CpResult<()> {
+    pub fn start_logger(&mut self, logger_name: &str, pipeline_name: &str, to_console: bool) -> CpResult<()> {
         if self.running_logger.is_some() {
             return Err(CpError::ComponentError(
                 "config.logger",
@@ -57,7 +57,7 @@ impl LoggerRegistry {
                 ));
             }
         };
-        logger.start(to_console)?;
+        logger.start(pipeline_name, to_console)?;
         let _ = self.running_logger.insert(logger_name.to_owned());
         Ok(())
     }
@@ -67,11 +67,13 @@ impl LoggerRegistry {
             return;
         }
         let logger_name = self.running_logger.as_ref().unwrap();
-        if let Some(x) = &self.get_logger(logger_name) { info!(
-            "Logger {}: Printed output to {}",
-            logger_name,
-            x._final_output_path.clone().unwrap_or("console".to_owned())
-        ) }
+        if let Some(x) = &self.get_logger(logger_name) {
+            info!(
+                "Logger {}: Printed output to {}",
+                logger_name,
+                x._final_output_path.clone().unwrap_or("console".to_owned())
+            )
+        }
     }
 }
 
@@ -269,8 +271,8 @@ second_log:
             dir_path, dir_path
         );
         let mut reg = create_logger_registry(&config);
-        reg.start_logger("base_log", true).unwrap();
-        assert!(reg.start_logger("second_log", true).is_err());
+        reg.start_logger("base_log", "test", true).unwrap();
+        assert!(reg.start_logger("second_log", "test", true).is_err());
         fs::remove_dir_all(dir_path).unwrap();
     }
 }

--- a/capport_core/src/context/mod.rs
+++ b/capport_core/src/context/mod.rs
@@ -1,4 +1,5 @@
 pub mod common;
+pub mod envvar;
 pub mod logger;
 pub mod model;
 pub mod pipeline;

--- a/capport_core/src/logger/common.rs
+++ b/capport_core/src/logger/common.rs
@@ -11,6 +11,10 @@ const DEFAULT_LOG_LEVEL: log::LevelFilter = log::LevelFilter::Info;
 const DEFAULT_LOG_PREFIX: &str = "programlog_";
 const DEFAULT_TIMESTAMP_SUFFIX: &str = "%Y-%m-%d_%H%M%S.log";
 
+pub const DEFAULT_KEYWORD_REFDATE_DIR: &str = "__refdate__";
+pub const DEFAULT_KEYWORD_OUTPUT_DIR: &str = "__output__";
+pub const DEFAULT_KEYWORD_CONFIG_DIR: &str = "__config__";
+
 const COLOR_DEBUG: Color = Color::Magenta;
 const COLOR_INFO: Color = Color::BrightGreen;
 const COLOR_WARN: Color = Color::BrightYellow;
@@ -75,7 +79,9 @@ impl Logger {
             )
         })
     }
-    pub fn start(&mut self, to_stdout: bool) -> CpResult<()> {
+
+    // TODO: use pipeline_name and env var for logging directory
+    pub fn start(&mut self, _pipeline_name: &str, to_stdout: bool) -> CpResult<()> {
         let colors = ColoredLevelConfig::new()
             .debug(COLOR_DEBUG)
             .info(COLOR_INFO)

--- a/capport_core/src/logger/common.rs
+++ b/capport_core/src/logger/common.rs
@@ -1,18 +1,21 @@
 use fern::colors::{Color, ColoredLevelConfig};
 use serde::{Deserialize, Deserializer, de};
 
-use crate::{context::envvar::get_env_var_str, util::{
-    common::get_utc_time_str_now,
-    error::{CpError, CpResult},
-}};
+use crate::{
+    context::envvar::get_env_var_str,
+    util::{
+        common::get_utc_time_str_now,
+        error::{CpError, CpResult},
+    },
+};
 
 pub const DEFAULT_CONSOLE_LOGGER_NAME: &str = "__stdout__";
 const DEFAULT_LOG_LEVEL: log::LevelFilter = log::LevelFilter::Info;
 const DEFAULT_LOG_PREFIX: &str = "programlog_";
 const DEFAULT_TIMESTAMP_SUFFIX: &str = "%Y-%m-%d_%H%M%S.log";
 
-pub const DEFAULT_KEYWORD_REF_DATETIME_DIR: &str = "REF_DATETIME";
-pub const DEFAULT_KEYWORD_REF_DATE_DIR: &str = "REF_DATE";
+pub const DEFAULT_KEYWORD_REF_DATETIME: &str = "REF_DATETIME";
+pub const DEFAULT_KEYWORD_REF_DATE: &str = "REF_DATE";
 pub const DEFAULT_KEYWORD_OUTPUT_DIR: &str = "OUTPUT_DIR";
 pub const DEFAULT_KEYWORD_CONFIG_DIR: &str = "CONFIG_DIR";
 

--- a/capport_core/src/logger/common.rs
+++ b/capport_core/src/logger/common.rs
@@ -1,10 +1,10 @@
 use fern::colors::{Color, ColoredLevelConfig};
 use serde::{Deserialize, Deserializer, de};
 
-use crate::util::{
+use crate::{context::envvar::get_env_var_str, util::{
     common::get_utc_time_str_now,
     error::{CpError, CpResult},
-};
+}};
 
 pub const DEFAULT_CONSOLE_LOGGER_NAME: &str = "__stdout__";
 const DEFAULT_LOG_LEVEL: log::LevelFilter = log::LevelFilter::Info;
@@ -72,6 +72,9 @@ impl Logger {
         }
     }
     pub fn get_full_prefix(&self) -> Option<String> {
+        // TODO: Remove the print stmt when the correct prefixing is complete
+        let output_dir = get_env_var_str(DEFAULT_KEYWORD_OUTPUT_DIR).unwrap_or("".to_owned());
+        println!("{}", output_dir);
         self.output.as_ref().map(|filepath| {
             format!(
                 "{}/{}",

--- a/capport_core/src/logger/common.rs
+++ b/capport_core/src/logger/common.rs
@@ -11,9 +11,10 @@ const DEFAULT_LOG_LEVEL: log::LevelFilter = log::LevelFilter::Info;
 const DEFAULT_LOG_PREFIX: &str = "programlog_";
 const DEFAULT_TIMESTAMP_SUFFIX: &str = "%Y-%m-%d_%H%M%S.log";
 
-pub const DEFAULT_KEYWORD_REFDATE_DIR: &str = "__refdate__";
-pub const DEFAULT_KEYWORD_OUTPUT_DIR: &str = "__output__";
-pub const DEFAULT_KEYWORD_CONFIG_DIR: &str = "__config__";
+pub const DEFAULT_KEYWORD_REF_DATETIME_DIR: &str = "REF_DATETIME";
+pub const DEFAULT_KEYWORD_REF_DATE_DIR: &str = "REF_DATE";
+pub const DEFAULT_KEYWORD_OUTPUT_DIR: &str = "OUTPUT_DIR";
+pub const DEFAULT_KEYWORD_CONFIG_DIR: &str = "CONFIG_DIR";
 
 const COLOR_DEBUG: Color = Color::Magenta;
 const COLOR_INFO: Color = Color::BrightGreen;

--- a/capport_core/src/pipeline/context.rs
+++ b/capport_core/src/pipeline/context.rs
@@ -171,12 +171,10 @@ impl<ResultType: Clone, ServiceDistributor> PipelineContext<ResultType, ServiceD
         let lr = &mut self.logger_registry;
         match pipeline_name {
             Some(pipeline) => lr.start_logger(logger_name, pipeline.as_str(), to_console),
-            None => {
-                Err(CpError::PipelineError(
-                    "Pipeline not set yet",
-                    "No pipeline set yet before `init_log` called".to_owned(),
-                ))
-            }
+            None => Err(CpError::PipelineError(
+                "Pipeline not set yet",
+                "No pipeline set yet before `init_log` called".to_owned(),
+            )),
         }
     }
 

--- a/capport_core/src/pipeline/runner.rs
+++ b/capport_core/src/pipeline/runner.rs
@@ -10,7 +10,7 @@ use super::{context::PipelineContext, results::PipelineResults};
 pub struct PipelineRunner;
 impl PipelineRunner {
     pub fn run_lazy<S>(ctx: Arc<dyn PipelineContext<LazyFrame, S>>) -> CpResult<PipelineResults<LazyFrame>> {
-        let pipeline = match ctx.get_curr_pipeline() {
+        let pipeline = match ctx.get_pipeline() {
             Some(p) => p,
             None => {
                 return Err(CpError::PipelineError(
@@ -67,7 +67,7 @@ mod tests {
 
     fn create_context(pipeline: Pipeline) -> Arc<DefaultContext<LazyFrame, ()>> {
         let mut ctx = raw_context();
-        ctx.set_curr_pipeline(pipeline).unwrap();
+        ctx.set_pipeline(pipeline).unwrap();
         Arc::new(ctx)
     }
 

--- a/capport_core/src/pipeline/runner.rs
+++ b/capport_core/src/pipeline/runner.rs
@@ -1,17 +1,25 @@
 use std::sync::Arc;
 
+use log::info;
 use polars::prelude::LazyFrame;
 
-use crate::util::error::CpResult;
+use crate::util::error::{CpError, CpResult};
 
-use super::{common::Pipeline, context::PipelineContext, results::PipelineResults};
+use super::{context::PipelineContext, results::PipelineResults};
 
 pub struct PipelineRunner;
 impl PipelineRunner {
-    pub fn run_lazy<S>(
-        ctx: Arc<dyn PipelineContext<LazyFrame, S>>,
-        pipeline: &Pipeline,
-    ) -> CpResult<PipelineResults<LazyFrame>> {
+    pub fn run_lazy<S>(ctx: Arc<dyn PipelineContext<LazyFrame, S>>) -> CpResult<PipelineResults<LazyFrame>> {
+        let pipeline = match ctx.get_curr_pipeline() {
+            Some(p) => p,
+            None => {
+                return Err(CpError::PipelineError(
+                    "No pipeline found in context",
+                    "PipelineContext requires a pipeline before runner can execute".to_string(),
+                ));
+            }
+        };
+        info!("Initating pipeline: {}", &pipeline.label);
         for stage in &pipeline.stages {
             let task = ctx.get_task(&stage.task, &stage.args)?;
             task(ctx.clone())?;
@@ -35,7 +43,7 @@ mod tests {
         },
         pipeline::{
             common::{Pipeline, PipelineStage},
-            context::DefaultContext,
+            context::{DefaultContext, PipelineContext},
             results::PipelineResults,
         },
         task::noop::NoopTask,
@@ -47,14 +55,20 @@ mod tests {
         PipelineStage::new(name, "noop", &serde_yaml_ng::Value::Null)
     }
 
-    fn create_context() -> Arc<DefaultContext<LazyFrame, ()>> {
-        Arc::new(DefaultContext::new(
+    fn raw_context() -> DefaultContext<LazyFrame, ()> {
+        DefaultContext::new(
             ModelRegistry::new(),
             TransformRegistry::new(),
             TaskDictionary::new(vec![("noop", generate_lazy_task::<NoopTask, ()>())]),
             (),
             LoggerRegistry::new(),
-        ))
+        )
+    }
+
+    fn create_context(pipeline: Pipeline) -> Arc<DefaultContext<LazyFrame, ()>> {
+        let mut ctx = raw_context();
+        ctx.set_curr_pipeline(pipeline).unwrap();
+        Arc::new(ctx)
     }
 
     #[test]
@@ -68,8 +82,8 @@ mod tests {
             .map(|x| Pipeline::new("noop", &x))
             .collect::<Vec<_>>();
         n_pipelines.iter().for_each(|pipeline| {
-            let ctx = create_context();
-            let actual = PipelineRunner::run_lazy(ctx.clone(), pipeline).unwrap();
+            let ctx = create_context(pipeline.clone());
+            let actual = PipelineRunner::run_lazy(ctx.clone()).unwrap();
             assert_eq!(actual, PipelineResults::<LazyFrame>::default());
         });
     }
@@ -80,7 +94,13 @@ mod tests {
             "invalid",
             &[PipelineStage::new("not_found", "nooop", &serde_yaml_ng::Value::Null)],
         );
-        let ctx = create_context();
-        assert!(PipelineRunner::run_lazy(ctx.clone(), &pipeline).is_err());
+        let ctx = create_context(pipeline.clone());
+        assert!(PipelineRunner::run_lazy(ctx.clone()).is_err());
+    }
+
+    #[test]
+    fn invalid_no_pipeline() {
+        let ctx = Arc::new(raw_context());
+        assert!(PipelineRunner::run_lazy(ctx.clone()).is_err());
     }
 }

--- a/capport_core/src/util/args.rs
+++ b/capport_core/src/util/args.rs
@@ -12,7 +12,10 @@ pub struct RunPipelineArgs {
     #[argh(option, short = 'p', description = "name of pipeline to run")]
     pub pipeline: String,
 
-    #[argh(option, short = 'd', description = "reference datetime of pipeline input")]
+    #[argh(option, short = 'd', description = "reference date of pipeline input")]
+    pub date: Option<String>,
+
+    #[argh(option, short = 'T', description = "reference datetime of pipeline input")]
     pub datetime: Option<String>,
 
     #[argh(switch, short = 'C', description = "print output to console")]

--- a/capport_core/src/util/common.rs
+++ b/capport_core/src/util/common.rs
@@ -28,24 +28,22 @@ pub fn parse_date_str(datetime_str: &str) -> CpResult<NaiveDate> {
             }
         }
     }
-    return Err(CpError::RawError(std::io::Error::new(
+    Err(CpError::RawError(std::io::Error::new(
         std::io::ErrorKind::InvalidInput,
         format!(
             "Invalid date `{}` parsed, only the following patterns are recognized: {:?}",
             datetime_str, &RECOGNIZED_DATE_PATTERNS
         ),
-    )));
+    )))
 }
 
 pub fn parse_datetime_str(datetime_str: &str) -> CpResult<DateTime<FixedOffset>> {
     match datetime_str.parse() {
-        Ok(x) => return Ok(x),
-        Err(e) => {
-            return Err(CpError::RawError(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Invalid datetime `{}` parsed, {:?}", datetime_str, e),
-            )));
-        }
+        Ok(x) => Ok(x),
+        Err(e) => Err(CpError::RawError(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Invalid datetime `{}` parsed, {:?}", datetime_str, e),
+        ))),
     }
 }
 

--- a/capport_core/src/util/common.rs
+++ b/capport_core/src/util/common.rs
@@ -1,4 +1,5 @@
-use chrono::Utc;
+use chrono::{DateTime, FixedOffset, NaiveDate, Utc};
+use log::debug;
 use polars::{df, frame::DataFrame, prelude::PlSmallStr};
 use polars_lazy::frame::{IntoLazy, LazyFrame};
 use std::collections::HashMap;
@@ -7,12 +8,46 @@ use rand::{Rng, distr::Alphanumeric};
 
 use crate::parser::common::YamlRead;
 
-use super::error::CpResult;
+use super::error::{CpError, CpResult};
 
 pub const NYT: &str = "America/New_York";
 pub const UTC: &str = "UTC";
 
 pub type YamlValue = serde_yaml_ng::Value;
+
+pub const RECOGNIZED_DATE_PATTERNS: [&str; 2] = ["%Y-%m-%d", "%Y.%m.%d"];
+pub const RECOGNIZED_TIME_PATTERNS: [&str; 2] = ["%H:%M:%S", "%H.%M.%S"];
+
+pub fn parse_date_str(datetime_str: &str) -> CpResult<NaiveDate> {
+    for &pattern in &RECOGNIZED_DATE_PATTERNS {
+        match NaiveDate::parse_from_str(datetime_str, pattern) {
+            Ok(x) => return Ok(x),
+            Err(e) => {
+                debug!("Date string `{}` cannot be parsed with pattern `{}`", pattern, e);
+                println!("Date string `{}` cannot be parsed with pattern `{}`", pattern, e);
+            }
+        }
+    }
+    return Err(CpError::RawError(std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!(
+            "Invalid date `{}` parsed, only the following patterns are recognized: {:?}",
+            datetime_str, &RECOGNIZED_DATE_PATTERNS
+        ),
+    )));
+}
+
+pub fn parse_datetime_str(datetime_str: &str) -> CpResult<DateTime<FixedOffset>> {
+    match datetime_str.parse() {
+        Ok(x) => return Ok(x),
+        Err(e) => {
+            return Err(CpError::RawError(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("Invalid datetime `{}` parsed, {:?}", datetime_str, e),
+            )));
+        }
+    }
+}
 
 pub fn get_utc_time_str_now() -> String {
     Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, false)

--- a/capport_default/src/main.rs
+++ b/capport_default/src/main.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use capport_core::context::envvar::EnvironmentVariableRegistry;
 use capport_core::context::logger::LoggerRegistry;
 use capport_core::context::task::TaskDictionary;
 use capport_core::context::{model::ModelRegistry, pipeline::PipelineRegistry, transform::TransformRegistry};
@@ -13,6 +14,7 @@ use polars::prelude::LazyFrame;
 
 fn main() {
     let args: RunPipelineArgs = argh::from_env();
+    let _ = EnvironmentVariableRegistry::from_args(&args); // Need to setup env reg
     let config_files = read_configs(&args.config_dir, &["yml", "yaml"]).unwrap();
     let mut pack = pack_configs_from_files(&config_files).unwrap();
     let model_reg = ModelRegistry::from(&mut pack).expect("Failed to build model registry");

--- a/capport_default/src/main.rs
+++ b/capport_default/src/main.rs
@@ -26,16 +26,16 @@ fn main() {
     };
     let mut ctx_setup =
         DefaultContext::<LazyFrame, ()>::new(model_reg, transform_reg, TaskDictionary::default(), (), logger_reg);
-    ctx_setup
-        .init_log(console_logger_name, args.print_to_console)
-        .expect("Failed to initialize logging");
     let pipeline = match pipeline_reg.get_pipeline(&args.pipeline) {
         Some(x) => x,
         None => panic!("Pipeline `{}` not found in pipeline registry", &args.pipeline),
     };
     ctx_setup
-        .set_curr_pipeline(pipeline.clone())
+        .set_pipeline(pipeline.clone())
         .expect("Failed to attach pipeline to context");
+    ctx_setup
+        .init_log(console_logger_name, args.print_to_console)
+        .expect("Failed to initialize logging");
     let ctx = Arc::new(ctx_setup);
     let pipeline_results = match PipelineRunner::run_lazy(ctx.clone()) {
         Ok(x) => x,

--- a/capport_default/src/main.rs
+++ b/capport_default/src/main.rs
@@ -29,13 +29,15 @@ fn main() {
     ctx_setup
         .init_log(console_logger_name, args.print_to_console)
         .expect("Failed to initialize logging");
-    let ctx = Arc::new(ctx_setup);
     let pipeline = match pipeline_reg.get_pipeline(&args.pipeline) {
         Some(x) => x,
         None => panic!("Pipeline `{}` not found in pipeline registry", &args.pipeline),
     };
-    info!("Started running pipeline: {:?}", &pipeline);
-    let pipeline_results = match PipelineRunner::run_lazy(ctx.clone(), pipeline) {
+    ctx_setup
+        .set_curr_pipeline(pipeline.clone())
+        .expect("Failed to attach pipeline to context");
+    let ctx = Arc::new(ctx_setup);
+    let pipeline_results = match PipelineRunner::run_lazy(ctx.clone()) {
         Ok(x) => x,
         Err(e) => panic!("{}", e),
     };

--- a/capport_service/tests/mongo.rs
+++ b/capport_service/tests/mongo.rs
@@ -1,4 +1,3 @@
-
 use bson::doc;
 use capport_service::{
     context::service::{DefaultSvcConfig, DefaultSvcDistributor},

--- a/config/example/transform.yml
+++ b/config/example/transform.yml
@@ -20,10 +20,10 @@ transform:
     - join:
         join: PLAYER
         right_select:
-          entityid: entityid
-          firstname: firstname
-          lastname: lastname
-          age: age
+          entityid:
+          firstname:
+          lastname:
+          age:
         left_on: id
         right_on: entityid
         how: left

--- a/docs/envvar.md
+++ b/docs/envvar.md
@@ -1,0 +1,15 @@
+# Environment Variables
+
+## Overview
+
+Capport provides the ability to set environment variables for this running instance that any
+pipeline can access. The `EnvironmentVariableRegistry` can build and populate the default
+argument inputs from the command line. 
+
+- `CONFIG_DIR` [mandatory]
+- `OUTPUT_DIR` [mandatory]
+- `REF_DATE`
+- `REF_DATETIME`
+
+These can be referenced from any pipeline so long as the `EnvironmentVariableRegistry` is still
+alive. The variables get deregistered when the registry is dropped.


### PR DESCRIPTION
This registry is unique, like the pipeline registry it is not passed into the context.
Environment Variables by default includes 
- CONFIG_DIR, 
- OUTPUT_DIR
- REF_DATE
- REF_DATETIME

Deregisters the env vars when it goes out of context, so a bit of a pseudo RAII