### PR TITLE
Add join tests

### DIFF
--- a/cp_core/src/task/transform/join.rs
+++ b/cp_core/src/task/transform/join.rs
@@ -163,6 +163,7 @@ mod tests {
     use crate::pipeline::context::{DefaultPipelineContext, PipelineContext};
     use crate::task::transform::common::TransformConfig;
     use crate::task::transform::config::{_JoinTransformConfig, JoinTransformConfig};
+    use crate::util::test::assert_frame_equal;
     use polars::df;
     use polars::prelude::{IntoLazy, JoinType, col};
     use std::collections::HashMap;
@@ -189,6 +190,27 @@ mod tests {
                     "left_col"      => [2, 2, 3, 3, 3, 3, 4, 4],
                     "left_data_2"   => [1, 2, 3, 3, 4, 4, 5, 6],
                     "data_1"        => [Some(2), Some(2), Some(3), Some(4), Some(3), Some(4), None, None],
+                ),
+            ),
+            (
+                JoinType::Right,
+                df!(
+                    "col"           => [1, 2, 2, 3, 3, 3, 3],
+                    "data_2"        => [None, Some(1), Some(2), Some(3), Some(4), Some(3), Some(4)],
+                    "left_col"      => [None, Some(2), Some(2), Some(3), Some(3), Some(3), Some(3)],
+                    "left_data_2"   => [None, Some(1), Some(2), Some(3), Some(4), Some(3), Some(4)],
+                    "data_1"        => [1, 2, 2, 3, 3, 4, 4],
+                ),
+            ),
+            (
+                JoinType::Full,
+                df!(
+                    "col"           => [None, Some(2), Some(2), Some(3), Some(3), Some(3), Some(3), Some(4), Some(4)],
+                    "col_right"     => [Some(1), Some(2), Some(2), Some(3), Some(3), Some(3), Some(3), None, None],
+                    "data_1"        => [Some(1), Some(2), Some(2), Some(3), Some(3), Some(4), Some(4), None, None],
+                    "data_2"        => [None, Some(1), Some(2), Some(3), Some(4), Some(3), Some(4), Some(5), Some(6)],
+                    "left_col"      => [None, Some(2), Some(2), Some(3), Some(3), Some(3), Some(3), Some(4), Some(4)],
+                    "left_data_2"   => [None, Some(1), Some(2), Some(3), Some(4), Some(3), Some(4), Some(5), Some(6)],
                 ),
             ),
         ];
@@ -235,7 +257,7 @@ mod tests {
             .lazy();
 
             let actual = join.run(main, ctx).unwrap();
-            assert_eq!(actual.collect().unwrap(), expected.unwrap());
+            assert_frame_equal(actual.collect().unwrap(), expected.unwrap());
         }
     }
     #[test]

--- a/cp_core/src/util/test.rs
+++ b/cp_core/src/util/test.rs
@@ -1,1 +1,26 @@
+use polars::frame::DataFrame;
+use polars::prelude::SortMultipleOptions;
 
+pub fn sort_dataframe(df: DataFrame) -> DataFrame {
+    let mut df = df.clone();
+
+    let mut cols: Vec<String> = df.get_column_names().iter().map(|s| s.to_string()).collect();
+    cols.sort();
+    df = df.select(&cols).unwrap();
+
+    let sort_options = SortMultipleOptions {
+        descending: vec![false; cols.len()],
+        nulls_last: vec![false; cols.len()],
+        multithreaded: true,
+        maintain_order: false,
+        limit: None,
+    };
+    df.sort(cols, sort_options).unwrap()
+}
+
+pub fn assert_frame_equal(df1: DataFrame, df2: DataFrame) {
+    let df1 = sort_dataframe(df1);
+    let df2 = sort_dataframe(df2);
+
+    assert_eq!(df1, df2);
+}


### PR DESCRIPTION
I didn't test all types of joins because have issue asserting properly. It would be more robust to sort cols and rows before asserting. 

For some reason the order of cols of the output for my right join is not working well??? like it will output a, b, c. Then when I change some lines of code it will change to b, c, a? Going out rn, maybe will check again ltr

Nonetheless I think ok because we alr tested the join type arg is forwarded properly - lmk if you'd want me to test all types of joins (i.e. right + outer also).

Closes #122
